### PR TITLE
build: remove go env GO111MODULE, add upx to reduce image size

### DIFF
--- a/helper/Dockerfile-release
+++ b/helper/Dockerfile-release
@@ -1,10 +1,10 @@
 FROM golang:1.16.6-alpine3.14 as builder
 WORKDIR /app/dtm
-RUN go env -w GO111MODULE=on
 # RUN go env -w GOPROXY=https://mirrors.aliyun.com/goproxy/,direct
 EXPOSE 8080
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" app/main.go
+RUN apk add upx && upx main
 
 FROM alpine:3.14 as runner
 COPY --from=builder /app/dtm/main /app/dtm/


### PR DESCRIPTION
1. `GO111MODULE` is default to on from version 1.16
2. use `upx` to reduce binary size