### PR TITLE
fix: add callerskip with 1

### DIFF
--- a/dtmcli/dtmimp/utils.go
+++ b/dtmcli/dtmimp/utils.go
@@ -133,7 +133,7 @@ func InitLog() {
 		config.Encoding = "console"
 		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 	}
-	p, err := config.Build()
+	p, err := config.Build(zap.AddCallerSkip(1))
 	if err != nil {
 		log.Fatal("create logger failed: ", err)
 	}


### PR DESCRIPTION
- 跳过一个 caller, 不然的话打印的 caller 始终是 utils

应该把 logger 模块独立出来？不然现在 dtmsvr 打印日志还需要 import dtmcli/dtmimp 包，挺奇怪的